### PR TITLE
Update build environment:

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,7 +116,6 @@ dependencies {
 //    implementation 'org.jraf:jraf-android-util:1.0.0'
     kapt "org.jraf:prefs-compiler:$versions.prefs"
     implementation "org.jraf:prefs:$versions.prefs"
-    implementation "org.jraf:android-wear-color-picker:$versions.wearColorPicker"
 
     // Necessary to have Kotlin and dataBinding at the same time
     kapt "com.android.databinding:compiler:$versions.androidGradlePlugin"  // <- Ici

--- a/app/src/main/kotlin/org/jraf/android/simplewatchface2/configuration/main/MainConfigurationFragment.kt
+++ b/app/src/main/kotlin/org/jraf/android/simplewatchface2/configuration/main/MainConfigurationFragment.kt
@@ -29,9 +29,9 @@ import android.content.Intent
 import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
 import android.preference.PreferenceFragment
-import org.jraf.android.androidwearcolorpicker.app.ColorPickActivity
 import org.jraf.android.simplewatchface2.BuildConfig
 import org.jraf.android.simplewatchface2.R
+import org.jraf.android.simplewatchface2.configuration.main.colorpick.ColorPickActivity
 import org.jraf.android.simplewatchface2.prefs.ConfigurationConstants
 import org.jraf.android.simplewatchface2.prefs.ConfigurationPrefs
 import org.jraf.android.util.about.AboutActivityIntentBuilder
@@ -100,7 +100,7 @@ class MainConfigurationFragment : PreferenceFragment() {
         super.onActivityResult(requestCode, resultCode, data)
         if (resultCode != Activity.RESULT_OK) return
 
-        val pickedColor = ColorPickActivity.getPickedColor(data)
+        val pickedColor = data?.getIntExtra(ColorPickActivity.EXTRA_RESULT, 0)
         when (requestCode) {
             ConfigurationConstants.KEY_COLOR_BACKGROUND.asRequestCode() -> mPrefs.colorBackground = pickedColor
             ConfigurationConstants.KEY_COLOR_HAND_HOUR.asRequestCode() -> mPrefs.colorHandHour = pickedColor

--- a/build.gradle
+++ b/build.gradle
@@ -16,19 +16,19 @@ buildscript {
         dexCountPlugin = '0.8.1'
         libFrc = '1.7.1'
 
-        compileSdk = 26
-        targetSdk = 26
+        compileSdk = 27
+        targetSdk = 27
 
-        buildTools = '26.0.2'
+        buildTools = '27.0.2'
         kotlin = '1.1.51'
-        supportLibrary = '26.1.0'
-        playServices = '11.4.2'
+        supportLibrary = '27.0.2'
+        playServices = '11.8.0'
         espresso = '3.0.1'
         junit = '4.12'
         robolectric = '3.4.2'
         fest = '2.0M10'
         crashlytics = '2.6.8'
-        androidWearable = '2.0.5'
+        androidWearable = '2.2.0'
         prefs = '1.2.2'
         androidCrop = '1.0.1'
         wearColorPicker = '1.0.2'


### PR DESCRIPTION
* Remove color picker library dependency
* Update `compileSdk` and `targetSdk` from 26 to 27
* Update `buildTools` from                 26.0.2 to 27.0.2
* Update support library form              26.1.0 to 27.0.2
* Update play services from                11.4.2 to 11.8.0
* Update android wearable from             2.0.5 to 2.2.0

Note, in order for this to build on my machine, I had to use a local version of jraf utils that uses gradle plugin 3.0.1 instead of 3.1.0-alpha06.